### PR TITLE
Remove pandas_array import from __init__.py

### DIFF
--- a/pint/__init__.py
+++ b/pint/__init__.py
@@ -22,7 +22,6 @@ from .errors import (DimensionalityError, OffsetUnitCalculusError,
 from .util import pi_theorem, logger
 
 from .context import Context
-from .pandas_array import QuantityArray
 
 
 try:                # pragma: no cover


### PR DESCRIPTION
This should mean that all the tests pass again.

Given pint's focus on avoiding dependencies, we shouldn't import the pandas interface by default (as it depends on pandas). If users want it, they'll have to do `from pint.pandas_array import QuantityArray` which is a little longer than `from pint import QuantityArray` but I think that's ok as it's a specialised usage.